### PR TITLE
Update Client.java

### DIFF
--- a/src/main/java/net/ser1/stomp/Client.java
+++ b/src/main/java/net/ser1/stomp/Client.java
@@ -57,10 +57,15 @@ public class Client extends Stomp implements MessageReceiver {
         header.put("login", login);
         header.put("passcode", pass);
         transmit(Command.CONNECT, header, null);
+        // Busy loop bail out
+        int x=0;
         try {
             String error = null;
             while (!isConnected() && ((error = nextError()) == null)) {
                 Thread.sleep(100);
+                if (x++ > 20) {
+                    throw new LoginException("Did not connect in time!");
+                }
             }
             if (error != null) throw new LoginException(error);
         } catch (InterruptedException e) {


### PR DESCRIPTION
Added a bail out condition to the busy loop based on the practical (production!) experience that it can hang once in 10.000 times or so. Ie the condition that no error is reported but the client also never get the isConnected() condition flagged. Maybe due to unstable network conditions etc, ie. undisclosed exernal reasons.
